### PR TITLE
date render fix - <p> added

### DIFF
--- a/src/components/layout/Days.js
+++ b/src/components/layout/Days.js
@@ -23,13 +23,11 @@ export default function Days({ type = 'today' }) {
   }
 
   return (
-    <>
       <p>
       <time dateTime={date.toISOString()}>
       {format(date, 'EEEE do MMMM yyyy')}
     </time>
       </p>
-    </>
   );
 }
 

--- a/src/components/layout/Days.js
+++ b/src/components/layout/Days.js
@@ -23,9 +23,13 @@ export default function Days({ type = 'today' }) {
   }
 
   return (
-    <time dateTime={date.toISOString()}>
+    <>
+      <p>
+      <time dateTime={date.toISOString()}>
       {format(date, 'EEEE do MMMM yyyy')}
     </time>
+      </p>
+    </>
   );
 }
 


### PR DESCRIPTION
Missing <p> in the return, means it always has to be added in the component you're trying to render it to. 

now can just be called in components like

```<Days type="today" />```